### PR TITLE
Add concurrency to template test and push_to_ghcr workflows

### DIFF
--- a/template/{% if ci == 'github' %}.github{% endif %}/workflows/test.yml.jinja
+++ b/template/{% if ci == 'github' %}.github{% endif %}/workflows/test.yml.jinja
@@ -10,6 +10,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.head_ref || github.ref_name }}{% endraw %}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/template/{% if ci == 'github' %}.github{% endif %}/workflows/{% if use_app %}push_to_ghcr.yml{% endif %}
+++ b/template/{% if ci == 'github' %}.github{% endif %}/workflows/{% if use_app %}push_to_ghcr.yml{% endif %}
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build_and_push:
     name: Build and push


### PR DESCRIPTION
Cancel in-progress runs on the same branch so successive pushes don't queue redundant runs or race to push the same Docker image tag.